### PR TITLE
Add Pomodoro Timer CLI (Python)

### DIFF
--- a/python/pomodoro-timer-README.md
+++ b/python/pomodoro-timer-README.md
@@ -1,0 +1,44 @@
+# Pomodoro Timer CLI
+
+A simple Pomodoro Timer CLI tool that helps track work intervals and breaks using the Pomodoro Technique.
+
+## Usage
+
+```bash
+python pomodoro_timer.py
+```
+
+## Features
+
+- Customizable work session duration (default: 25 minutes)
+- Countdown display with minutes and seconds
+- Optional 5-minute break after work session
+- Keyboard interrupt support (Ctrl+C to stop)
+- Clear visual timer display
+
+## How it Works
+
+1. Enter desired work duration (or press Enter for default 25 minutes)
+2. Timer counts down and displays remaining time
+3. Notification when time is up
+4. Option to start a 5-minute break
+
+## Example
+
+```
+=== Pomodoro Timer CLI ===
+Default: 25 minutes work, 5 minutes break
+
+Enter work duration in minutes (default 25): 25
+
+Work session started: 25 minutes
+Press Ctrl+C to stop the timer
+
+Work: 24:59
+```
+
+## Tips
+
+- Use for focused work sessions
+- Take regular breaks to maintain productivity
+- Adjust duration based on your needs

--- a/python/pomodoro_timer.py
+++ b/python/pomodoro_timer.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Author: Rishabh
+# Pomodoro Timer CLI - helps track work intervals and breaks
+
+import time
+import sys
+
+def countdown_timer(minutes, session_type="Work"):
+    """Run a countdown timer for the specified number of minutes."""
+    total_seconds = minutes * 60
+
+    print(f"\n{session_type} session started: {minutes} minutes")
+    print("Press Ctrl+C to stop the timer\n")
+
+    try:
+        for remaining in range(total_seconds, 0, -1):
+            mins, secs = divmod(remaining, 60)
+            timer_display = f"{mins:02d}:{secs:02d}"
+            print(f"\r{session_type}: {timer_display}", end="")
+            sys.stdout.flush()
+            time.sleep(1)
+
+        print(f"\n\n🔔 {session_type} session complete! Time's up!")
+        return True
+
+    except KeyboardInterrupt:
+        print("\n\nTimer stopped by user.")
+        return False
+
+def main():
+    print("=== Pomodoro Timer CLI ===")
+    print("Default: 25 minutes work, 5 minutes break")
+
+    try:
+        work_input = input("\nEnter work duration in minutes (default 25): ").strip()
+        work_minutes = int(work_input) if work_input else 25
+
+        if work_minutes <= 0:
+            print("Duration must be positive.")
+            return
+
+    except ValueError:
+        print("Invalid input. Using default 25 minutes.")
+        work_minutes = 25
+
+    # Work session
+    completed = countdown_timer(work_minutes, "Work")
+
+    if completed:
+        # Ask if user wants a break
+        break_choice = input("\nStart a 5-minute break? (y/n): ").strip().lower()
+        if break_choice == 'y':
+            countdown_timer(5, "Break")
+            print("\nGreat session! Keep up the productivity!")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
A CLI tool implementing the Pomodoro Technique for productivity tracking with customizable work/break sessions.

## Tasks Completed
- [x] Create `pomodoro_timer.py` file
- [x] Implement countdown timer with minutes and seconds display
- [x] Allow user input for timer duration (default 25 minutes)
- [x] Add real-time countdown display (MM:SS format)
- [x] Implement optional 5-minute break session
- [x] Add keyboard interrupt support (Ctrl+C)
- [x] Print message when time is up
- [x] Test CLI version in terminal
- [x] Add README explaining usage

## Files Added
- `python/pomodoro_timer.py` - Pomodoro timer implementation
- `python/pomodoro-timer-README.md` - Usage instructions and productivity tips

Fixes #27
